### PR TITLE
Rip off the syntax error when pressing cmd key

### DIFF
--- a/gentlestatus.safariextension/injectedscript.js
+++ b/gentlestatus.safariextension/injectedscript.js
@@ -56,6 +56,8 @@ if (isInIFrame === false)
 
 	function UpdateMessage()
 	{
+		if (typeof linkHref == "undefined") return;
+
 		var intro = "";
 		var outro = "";
 		var linkShow = parseURL(linkHref).resolved;


### PR DESCRIPTION
In some cases I was getting a syntax error while hitting the cmd key because `linkHref` var was not defined… I've just added a `typeof` check so the error log don't fill up with errors I don't mind on my front end development work. :3
